### PR TITLE
Add dark theme switch

### DIFF
--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -1,0 +1,27 @@
+body[data-theme='dark'] {
+    background-color: #1f2937;
+    color: #f3f4f6;
+}
+body[data-theme='dark'] header,
+body[data-theme='dark'] footer {
+    background-color: #111827;
+    color: #f3f4f6;
+}
+body[data-theme='dark'] .bg-white {
+    background-color: #1f2937 !important;
+}
+body[data-theme='dark'] .bg-gray-50 {
+    background-color: #374151 !important;
+}
+body[data-theme='dark'] .text-gray-900 {
+    color: #f3f4f6 !important;
+}
+body[data-theme='dark'] .text-gray-700 {
+    color: #e5e7eb !important;
+}
+body[data-theme='dark'] .text-gray-500 {
+    color: #9ca3af !important;
+}
+body[data-theme='dark'] .border-gray-200 {
+    border-color: #4b5563 !important;
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -10,11 +10,12 @@
     
     <!-- Monaco Editor CSS -->
     <link rel="stylesheet" data-name="vs/editor/editor.main" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.css">
+    <link rel="stylesheet" href="{{ asset('css/theme.css') }}">
     
     <!-- Custom CSS -->
     {% block stylesheets %}{% endblock %}
 </head>
-<body class="min-h-screen flex flex-col bg-gray-50">
+<body data-theme="light" class="min-h-screen flex flex-col bg-gray-50">
     <!-- Header -->
     <header class="bg-white shadow-sm border-b border-gray-200">
         <nav class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -67,6 +68,7 @@
                             </div>
                         </div>
                     </div>
+                        <button id="theme-toggle" class="text-gray-700 hover:text-gray-900 text-lg" aria-label="Toggle theme">🌙</button>
 
                     <!-- User Menu -->
                     {% if app.user %}
@@ -261,6 +263,30 @@
 
         // Monaco Editor configuration
         require.config({ paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs' }});
+        window.monacoTheme = localStorage.getItem("theme") === "dark" ? "vs-dark" : "vs-light";
+        function applyTheme(theme) {
+            document.body.setAttribute("data-theme", theme);
+            localStorage.setItem("theme", theme);
+            window.monacoTheme = theme === "dark" ? "vs-dark" : "vs-light";
+            if (window.monaco && window.monaco.editor) {
+                monaco.editor.setTheme(window.monacoTheme);
+            }
+            const tbtn = document.getElementById("theme-toggle");
+            if (tbtn) {
+            tbtn.textContent = theme === 'dark' ? '☀' : '🌙';
+            }
+        }
+
+        document.addEventListener("DOMContentLoaded", function() {
+            applyTheme(localStorage.getItem("theme") || "light");
+            const tbtn = document.getElementById("theme-toggle");
+            if (tbtn) {
+                tbtn.addEventListener("click", function() {
+                    const newTheme = document.body.getAttribute("data-theme") === "dark" ? "light" : "dark";
+                    applyTheme(newTheme);
+                });
+            }
+        });
     </script>
 
     {% block javascripts %}{% endblock %}

--- a/templates/converter/index.html.twig
+++ b/templates/converter/index.html.twig
@@ -129,7 +129,7 @@ class Order {
 User "1" --> "*" Order : places
 @enduml`,
         language: 'plaintext',
-        theme: 'vs-light',
+        theme: window.monacoTheme,
         minimap: { enabled: false },
         automaticLayout: true
     });
@@ -243,7 +243,7 @@ User "1" --> "*" Order : places
                 monaco.editor.create(document.getElementById(`file-editor-${index}`), {
                     value: file.content,
                     language: getMonacoLanguage(file.filename),
-                    theme: 'vs-light',
+                    theme: window.monacoTheme,
                     readOnly: true,
                     minimap: { enabled: false },
                     automaticLayout: true

--- a/templates/generator/index.html.twig
+++ b/templates/generator/index.html.twig
@@ -254,7 +254,7 @@ require([
     const jsonEditorInstance = monaco.editor.create(document.getElementById('json-editor'), {
         value: jsonExample,
         language: 'json',
-        theme: 'vs-light',
+        theme: window.monacoTheme,
         minimap: { enabled: false },
         automaticLayout: true
     });
@@ -339,7 +339,7 @@ require([
                             monaco.editor.create(document.getElementById(`file-editor-${index}`), {
                                 value: fileData.content,
                                 language: getMonacoLanguage(fileData.filename),
-                                theme: 'vs-light',
+                                theme: window.monacoTheme,
                                 readOnly: true,
                                 minimap: { enabled: false },
                                 automaticLayout: true

--- a/templates/uml_parser/index.html.twig
+++ b/templates/uml_parser/index.html.twig
@@ -98,7 +98,7 @@ class Order {
 User "1" --> "*" Order: places
 @enduml`,
         language: 'plaintext',
-        theme: 'vs-light',
+        theme: window.monacoTheme,
         minimap: { enabled: false },
         automaticLayout: true
     });
@@ -172,7 +172,7 @@ User "1" --> "*" Order: places
                 jsonEditor = monaco.editor.create(document.getElementById('json-editor'), {
                     value: JSON.stringify(data, null, 2),
                     language: 'json',
-                    theme: 'vs-light',
+                    theme: window.monacoTheme,
                     readOnly: true,
                     minimap: { enabled: false },
                     automaticLayout: true


### PR DESCRIPTION
## Summary
- allow toggling between light and dark theme
- propagate theme to Monaco editor instances
- add dark theme CSS overrides

## Testing
- `phpunit -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408e6eee788332bd808805d0364f81